### PR TITLE
Fixed 2 typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is the collection of all the plasmids designed during the "who's gene is it anyway" live streams.
 
-These plasmids are released as creative commons attribution-share alike. You may download them, modify them, even have them synthesized if you so choose or use them for commercial activity. But you must provide attribution to The Thought Emporium and Justin Atkin, and any derivitates you make must be released under the same license. See below link for details.
+These plasmids are released as creative commons attribution-share alike. You may download them, modify them, even have them synthesized if you so choose or use them for commercial activity. But you must provide attribution to The Thought Emporium and Justin Atkin, and any derivatives you make must be released under the same license. See the link below for details.
 https://creativecommons.org/licenses/by-sa/4.0/ 
 
 Link to channel: https://youtube.com/c/thethoughtemporium


### PR DESCRIPTION
Fixed typo in word "derivatives", added the article to the word "link" and moved word "below" after the word "link"