### PR TITLE
Include links to the videos mentioned

### DIFF
--- a/lactasev2/readme.md
+++ b/lactasev2/readme.md
@@ -1,4 +1,6 @@
-This is the new version of the lactase gene therapy plasmid. I've also included the old version for reference. DO NOT TEST THIS ON YOURSELF FFS.
+This is the new version of the lactase gene therapy plasmid. I've also included the old version for reference.
 
-Original video:
-Update Video:
+**DO NOT TEST THIS ON YOURSELF FFS.**
+
+Original video: [Developing a Permanent Treatment for Lactose Intolerance Using Gene Therapy (Feb 12, 2018)](https://youtu.be/J3FcbFqSoQY)  
+Update Video: [Am I still lactose tolerant? - Lactose Gene Therapy Update (May 13, 2020)](https://youtu.be/aoczYXJeMY4)  


### PR DESCRIPTION
The README file of the lavtasev2 project references two videos, but doesn't include links to them.  
This is addressed in this commit & PR.