### PR TITLE
Various codon scramble improvements

### DIFF
--- a/scripts/codonscromble/codonscromble.css
+++ b/scripts/codonscromble/codonscromble.css
@@ -1,0 +1,42 @@
+table {
+  border-collapse: collapse;
+}
+td, th {
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}
+tr:nth-child(even) {
+  background-color: #dddddd;
+}
+td.mono {
+    font-family: 'Courier New', Courier, monospace;
+}
+
+#codonkey {
+    vertical-align: baseline;
+    display:inline-block; 
+    white-space: pre;
+    text-align: right;
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+#codondict {
+    vertical-align: baseline;
+    display:inline-block;
+    white-space: pre;
+    border: 2px solid darkslategray;
+    padding: 4px;
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+#codonkey-container {
+    display:inline-block; 
+    margin-right: 6px;
+}
+
+#codondict-container {
+    display:inline-block;
+}

--- a/scripts/codonscromble/codonscromble.html
+++ b/scripts/codonscromble/codonscromble.html
@@ -79,9 +79,9 @@ V: gtt,gtc,gta,gtg
   <textarea id="codons" rows=10 cols=80
     placeholder="MAAKIFSILM LLALSACVLD ATIFPQYSQA PIAALLPPYL PSMTASVCEN PTLQPYRLQQ AIATSNLPLS PLLFQQSPAL SLVQSLVQTI RAQQLQQLVL PLINQVALAN LSPYSQQQQF LPFNQLSTLN LAAYLQQQLL PFSQLATAYS QQQQFLPFNQ LAALNPAAYL QQQILLPFGQ LATTNRASFL TQQQLLPFYQ QFSANPATLL QLQQLLPFVQ LALTNPAAFY QQHIIGGAIF *"></textarea>
   <p>
-    RNG seed: <input id="seed" type="text" placeholder="&lt;random&gt;"/>
-    <button onclick="codonsToDNA();">Convert Codons to DNA \/</button>
     <button onclick="DNAToCodons();">Convert DNA to Codons /\</button>
+    <button onclick="codonsToDNA();">Convert Codons to DNA \/</button>
+    <button onclick="runGCScan(-1);">Minimize GC ratio \/</button>
   </p>
   <div>DNA sequence (ignores whitespace and digits):</div>
   <textarea id="DNA" rows=10 cols=80 placeholder=""></textarea>

--- a/scripts/codonscromble/codonscromble.html
+++ b/scripts/codonscromble/codonscromble.html
@@ -79,7 +79,7 @@ V: gtt,gtc,gta,gtg
   <textarea id="codons" rows=10 cols=80
     placeholder="MAAKIFSILM LLALSACVLD ATIFPQYSQA PIAALLPPYL PSMTASVCEN PTLQPYRLQQ AIATSNLPLS PLLFQQSPAL SLVQSLVQTI RAQQLQQLVL PLINQVALAN LSPYSQQQQF LPFNQLSTLN LAAYLQQQLL PFSQLATAYS QQQQFLPFNQ LAALNPAAYL QQQILLPFGQ LATTNRASFL TQQQLLPFYQ QFSANPATLL QLQQLLPFVQ LALTNPAAFY QQHIIGGAIF *"></textarea>
   <p>
-    RNG seed: <input id="seed" type="text" />
+    RNG seed: <input id="seed" type="text" placeholder="&lt;random&gt;"/>
     <button onclick="codonsToDNA();">Convert Codons to DNA \/</button>
     <button onclick="DNAToCodons();">Convert DNA to Codons /\</button>
   </p>

--- a/scripts/codonscromble/codonscromble.html
+++ b/scripts/codonscromble/codonscromble.html
@@ -1,100 +1,99 @@
 <html>
-  <head>
-    <title>Codon Scrombler</title>
-    <meta charset="utf-8">
-    <script src="codonscromble.js"></script>
-    <style>
-table {
-  border-collapse: collapse;
-}
-td, th {
-  border: 1px solid #dddddd;
-  text-align: left;
-  padding: 8px;
-}
-tr:nth-child(even) {
-  background-color: #dddddd;
-}
-    </style>
-  </head>
-  <body>
-    <h1>Codon Scrombler</h1>
-    <p>This webpage converts an amino acid sequence to a randomized DNA sequence that codes for that amino acid sequence or vice versa.</p>
-    <p>Codon Dictionary</p>
-    <select id="dict" oninput="getDict()">
-      <option value="human">Human</option>
-      <option value="Drosophila">Drosophila</option>
-      <option value="mouse">Mouse</option>
-      <option value="saccharomyces">Saccharomyces</option>
-      <option value="Arabidopsis">Arabidopsis</option>
-      <option value="all">Pichia</option>
-      <option value="custom">Custom</option>
-    </select>
-      <p>Custom Codon Dictionary</p>
-      <textarea id="codondict" rows=24 cols=80 style="float: left; width: 75%;" oninput="onDictChange()">
-{
-"A": ["gct", "gcc", "gca", "gcg"],                 
-"R": ["cgt", "cgc", "cga", "cgg", "aga", "agg"],   
-"N": ["aat", "aac"],                               
-"D": ["gat", "gac"],                               
-"C": ["tgt", "tgc"],                               
-"Q": ["caa", "cag"],                               
-"E": ["gaa", "gag"],                               
-"G": ["ggt", "ggc", "gga", "ggg"],                 
-"H": ["cat", "cac"],                               
-"I": ["att", "atc", "ata"],                        
-"L": ["ctt", "ctc", "cta", "ctg", "tta", "ttg"],   
-"K": ["aaa", "aag"],                               
-"M": ["atg"],                                      
-"F": ["ttt", "ttc"],                               
-"P": ["cct", "ccc", "cca", "ccg"],                 
-"S": ["tct", "tcc", "tca", "tcg", "agt", "agc"],   
-"T": ["act", "acc", "aca", "acg"],                 
-"W": ["tgg"],                                      
-"Y": ["tat", "tac"],                               
-"V": ["gtt", "gtc", "gta", "gtg"],                 
-"*": ["taa", "tga", "tag"]                         
-}
-      </textarea>
-      <textarea rows=24 cols=80 style="float: left; width: 25%;">
 
-Alanine (Ala)
-Arginine (Arg)
-Asparagine (Asn)
-Aspartic acid (Asp)
-Cysteine (Cys)
-Glutamine (Gln)
-Glutamic acid (Glu)
-Glycine (Gly)
-Histidine (His)
-Isoleucine (Ile)
-Leucine (Leu)
-Lysine (Lys)
-Methionine (Met)
-Phenylalanine (Phe)
-Proline (Pro)
-Serine (Ser)
-Threonine (Thr)
-Tryptophan (Trp)
-Tyrosine (Tyr)
-Valine (Val)
-Stop
+<head>
+  <title>Codon Scrombler</title>
+  <meta charset="utf-8">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/seedrandom/3.0.5/seedrandom.min.js"></script>
+  <script src="codonscromble.js"></script>
+  <link href="codonscromble.css" rel="stylesheet" />
+</head>
 
-      </textarea>
-      <p>Codon sequence:</p>
-      <textarea id="codons" rows=10 cols=80 placeholder="MAAKIFSILM LLALSACVLD ATIFPQYSQA PIAALLPPYL PSMTASVCEN PTLQPYRLQQ AIATSNLPLS PLLFQQSPAL SLVQSLVQTI RAQQLQQLVL PLINQVALAN LSPYSQQQQF LPFNQLSTLN LAAYLQQQLL PFSQLATAYS QQQQFLPFNQ LAALNPAAYL QQQILLPFGQ LATTNRASFL TQQQLLPFYQ QFSANPATLL QLQQLLPFVQ LALTNPAAFY QQHIIGGAIF *"></textarea>
-      <p>
-        <button onclick="codonsToDNA();">Convert Codons to DNA \/</button>
-        <button onclick="DNAToCodons();">Convert DNA to Codons /\</button>
-      </p>
-      <p>DNA sequence:</p>
-      <textarea id="DNA" rows=10 cols=80 placeholder=""></textarea>
-      <p>Analytics:</p>
-      <div id="analytics"></div>
-      <p>Repeats:</p>
-      Minimum number of base pairs to test for repetitions: <input type="number" id="minrep" min="1" value="10"></input><br>
-      Maximum number of base pairs to test for repetitions: <input type="number" id="maxrep" min="1" value="30"></input><br>
-      <button onclick="checkForRepeats();">Check DNA for Repeats</button> 
-      <div id="repeats"></div>
-  </body>
+<body>
+  <h1>Codon Scrombler</h1>
+  <p>This webpage converts an amino acid sequence to a randomized DNA sequence that codes for that amino acid sequence
+    or vice versa.</p>
+  <h2>Codon Dictionary</h2>
+  <div>(edit if your organism does not use certain DNA sequences)</div>
+  <div>
+    <div id="codonkey-container">
+      <pre id="codonkey">
+Alanine = Ala = A
+Arginine = Arg = R
+Asparagine = Asn = N
+Aspartic acid = Asp = D
+Cysteine = Cys = C
+Glutamine = Gln = Q
+Glutamic acid = Glu = E
+Glycine = Gly = G
+Histidine = His = H
+Isoleucine = Ile = I
+Leucine = Leu = L
+Lysine = Lys = K
+Methionine = Met = M
+Phenylalanine = Phe = F
+Proline = Pro = P
+Serine = Ser = S
+Threonine = Thr = T
+Tryptophan = Trp = W
+Tyrosine = Tyr = Y
+Valine = Val = V
+Stop = *</pre>
+    </div>
+    <div id="codondict-container">
+      <pre id="codondict" contenteditable="true">
+A: gct,gcc,gca,gcg
+R: cgt,cgc,cga,cgg,aga,agg
+N: aat,aac
+D: gat,gac
+C: tgt,tgc
+Q: caa,cag
+E: gaa,gag
+G: ggt,ggc,gga,ggg
+H: cat,cac
+I: att,atc,ata
+L: ctt,ctc,cta,ctg,tta,ttg
+K: aaa,aag
+M: atg
+F: ttt,ttc
+P: cct,ccc,cca,ccg
+S: tct,tcc,tca,tcg,agt,agc
+T: act,acc,aca,acg
+W: tgg
+Y: tat,tac
+V: gtt,gtc,gta,gtg
+*: taa,tga,tag</pre>
+    </div>
+  </div>
+  <div id="preset-list">Presets:
+    <button onclick="loadPreset('arabidopsis');">Arabidopsis</button>
+    <button onclick="loadPreset('drosophila');">Drosophila</button>
+    <button onclick="loadPreset('human');">Human</button>
+    <button onclick="loadPreset('mouse');">Mouse</button>
+    <button onclick="loadPreset('all');">Pichia</button>
+    <button onclick="loadPreset('saccharomyces');">Saccharomyces</button>
+  </div>
+
+  <h2>Conversion</h2>
+
+  <div>Codon sequence:</div>
+  <textarea id="codons" rows=10 cols=80
+    placeholder="MAAKIFSILM LLALSACVLD ATIFPQYSQA PIAALLPPYL PSMTASVCEN PTLQPYRLQQ AIATSNLPLS PLLFQQSPAL SLVQSLVQTI RAQQLQQLVL PLINQVALAN LSPYSQQQQF LPFNQLSTLN LAAYLQQQLL PFSQLATAYS QQQQFLPFNQ LAALNPAAYL QQQILLPFGQ LATTNRASFL TQQQLLPFYQ QFSANPATLL QLQQLLPFVQ LALTNPAAFY QQHIIGGAIF *"></textarea>
+  <p>
+    RNG seed: <input id="seed" type="text" />
+    <button onclick="codonsToDNA();">Convert Codons to DNA \/</button>
+    <button onclick="DNAToCodons();">Convert DNA to Codons /\</button>
+  </p>
+  <div>DNA sequence (ignores whitespace and digits):</div>
+  <textarea id="DNA" rows=10 cols=80 placeholder=""></textarea>
+
+  <h4>Analytics:</h4>
+  <div id="analytics"></div>
+
+  <h2>Repeats:</h2>
+  <button onclick="checkForRepeats();">Check DNA for Repeats</button><br>
+  Minimum number of base pairs to test for repetitions: <input type="number" id="minrep" min="1" value="10"></input><br>
+  Maximum number of base pairs to test for repetitions: <input type="number" id="maxrep" min="1" value="30"></input><br>
+  <div id="repeats"></div>
+</body>
+
 </html>

--- a/scripts/codonscromble/codonscromble.js
+++ b/scripts/codonscromble/codonscromble.js
@@ -1,293 +1,283 @@
-var defaultCodonDicts = {
-"human":
-{
-"A": ["gct", "gcc", "gca"],
-"R": ["cgg", "aga", "agg"],
-"N": ["aat", "aac"],
-"D": ["gat", "gac"],
-"C": ["tgt", "tgc"],
-"Q": ["caa", "cag"],
-"E": ["gaa", "gag"],
-"G": ["ggt", "ggc", "gga", "ggg"],
-"H": ["cat", "cac"],
-"I": ["att", "atc"],
-"L": ["ctt", "ctc", "ctg", "ttg"],
-"K": ["aaa", "aag"],
-"M": ["atg"],
-"F": ["ttt", "ttc"],
-"P": ["cct", "ccc", "cca"],
-"S": ["tct", "tcc", "tca", "agt", "agc"],
-"T": ["act", "acc", "aca"],
-"W": ["tgg"],
-"Y": ["tat", "tac"],
-"V": ["gtt", "gtc", "gtg"],
-"*": ["taa", "tga", "tag"]
-},
-"Drosophila":
-{
-"A": ["gct", "gcc", "gca", "gcg"],
-"R": ["cgt", "cgc"],
-"N": ["aat", "aac"],
-"D": ["gat", "gac"],
-"C": ["tgt", "tgc"],
-"Q": ["caa", "cag"],
-"E": ["gaa", "gag"],
-"G": ["ggt", "ggc", "gga"],
-"H": ["cat", "cac"],
-"I": ["att", "atc"],
-"L": ["ctc", "ctg", "ttg"],
-"K": ["aaa", "aag"],
-"M": ["atg"],
-"F": ["ttt", "ttc"],
-"P": ["ccc", "cca", "ccg"],
-"S": ["tcc", "tcg", "agt", "agc"],
-"T": ["act", "acc", "aca", "acg"],
-"W": ["tgg"],
-"Y": ["tat", "tac"],
-"V": ["gtt", "gtc", "gtg"],
-"*": ["taa", "tga", "tag"]
-},
-"mouse":
-{
-"A": ["gct", "gcc", "gca"],
-"R": ["cgc", "cgg", "aga", "agg"],
-"N": ["aat", "aac"],
-"D": ["gat", "gac"],
-"C": ["tgt", "tgc"],
-"Q": ["caa", "cag"],
-"E": ["gaa", "gag"],
-"G": ["ggt", "ggc", "gga", "ggg"],
-"H": ["cat", "cac"],
-"I": ["att", "atc"],
-"L": ["ctt", "ctc", "ctg", "ttg"],
-"K": ["aaa", "aag"],
-"M": ["atg"],
-"F": ["ttt", "ttc"],
-"P": ["cct", "ccc", "cca"],
-"S": ["tct", "tcc", "tca", "agt", "agc"],
-"T": ["act", "acc", "aca"],
-"W": ["tgg"],
-"Y": ["tat", "tac"],
-"V": ["gtt", "gtc", "gtg"],
-"*": ["taa", "tga", "tag"]
-},
-"saccharomyces":
-{
-"A": ["gct", "gcc", "gca"],
-"R": ["aga", "agg"],
-"N": ["aat", "aac"],
-"D": ["gat", "gac"],
-"C": ["tgt", "tgc"],
-"Q": ["caa", "cag"],
-"E": ["gaa", "gag"],
-"G": ["ggt", "ggc", "gga"],
-"H": ["cat", "cac"],
-"I": ["att", "atc", "ata"],
-"L": ["ctt", "cta", "ctg", "tta", "ttg"],
-"K": ["aaa", "aag"],
-"M": ["atg"],
-"F": ["ttt", "ttc"],
-"P": ["cct", "cca"],
-"S": ["tct", "tcc", "tca", "agt", "agc"],
-"T": ["act", "acc", "aca"],
-"W": ["tgg"],
-"Y": ["tat", "tac"],
-"V": ["gtt", "gtc", "gta", "gtg"],
-"*": ["taa", "tga", "tag"]
-},
-"Arabidopsis":
-{
-"A": ["gct", "gcc", "gca"],
-"R": ["aga", "agg"],
-"N": ["aat", "aac"],
-"D": ["gat", "gac"],
-"C": ["tgt", "tgc"],
-"Q": ["caa", "cag"],
-"E": ["gaa", "gag"],
-"G": ["ggt", "ggc", "gga", "ggg"],
-"H": ["cat", "cac"],
-"I": ["att", "atc", "ata"],
-"L": ["ctt", "ctc", "cta", "ctg", "tta", "ttg"],
-"K": ["aaa", "aag"],
-"M": ["atg"],
-"F": ["ttt", "ttc"],
-"P": ["cct", "cca"],
-"S": ["tct", "tcc", "tca", "tcg", "agt", "agc"],
-"T": ["act", "acc", "aca"],
-"W": ["tgg"],
-"Y": ["tat", "tac"],
-"V": ["gtt", "gtc", "gta", "gtg"],
-"*": ["taa", "tga", "tag"]
-},
-"all":
-{
-"A": ["gct", "gcc", "gca", "gcg"],
-"R": ["cgt", "cgc", "cga", "cgg", "aga", "agg"],
-"N": ["aat", "aac"],
-"D": ["gat", "gac"],
-"C": ["tgt", "tgc"],
-"Q": ["caa", "cag"],
-"E": ["gaa", "gag"],
-"G": ["ggt", "ggc", "gga", "ggg"],
-"H": ["cat", "cac"],
-"I": ["att", "atc", "ata"],
-"L": ["ctt", "ctc", "cta", "ctg", "tta", "ttg"],
-"K": ["aaa", "aag"],
-"M": ["atg"],
-"F": ["ttt", "ttc"],
-"P": ["cct", "ccc", "cca", "ccg"],
-"S": ["tct", "tcc", "tca", "tcg", "agt", "agc"],
-"T": ["act", "acc", "aca", "acg"],
-"W": ["tgg"],
-"Y": ["tat", "tac"],
-"V": ["gtt", "gtc", "gta", "gtg"],
-"*": ["taa", "tga", "tag"]
-}
-}
-
-function prettyPrintCodonDict(selected) {
-  //selected is the selected codon
-  var r = "{\n";
-  var dict = defaultCodonDicts[selected];
-  for (codon in dict) {
-    r += '"' + codon + '": ' + JSON.stringify(dict[codon]) + ",\n";
+function codonMapping(reverse) {
+  let mapLines = document.getElementById("codondict").innerText.split("\n");
+  let mapping = {};
+  for (let line of mapLines) {
+    if(/^\s*$/.test(line)) continue;
+    let split = line.split(':', 3);
+    let codon = split[0].trim().toUpperCase();
+    let triplets = [];
+    for(let triplet of split[1].split(',')) {
+      triplets.push(triplet.trim().toLowerCase());
+    }
+    mapping[codon] = triplets;
   }
-  //remove the last comma
-  r = r.substring(0, r.length - 2);
-  r += "\n}";
-  return r;
-}
 
-var customDict = prettyPrintCodonDict("all");
-
-window.onload = function() {
-  getDict();
-}
-
-function onDictChange() {
-  var dictArea = document.getElementById("codondict");
-  customDict = dictArea.innerHTML;
-}
-
-function getDict() {
-  var selected = document.getElementById("dict").value;
-  var dictArea = document.getElementById("codondict");
-  if (selected == "custom") {
-    dictArea.disabled = false;
-    dictArea.innerHTML = customDict;
-    return JSON.parse(dictArea.value);
-  } else {
-    dictArea.disabled = true;
-    dictArea.innerHTML = prettyPrintCodonDict(selected);
-    return defaultCodonDicts[selected];
+  if (reverse) {
+    let reverseMapping = {};
+    for (let codon in mapping) {
+      for (let triplet of mapping[codon]) {
+        if (triplet in reverseMapping) {
+          alert("Duplicate triplet \"" + triplet + "\" for codon " + codon);
+        }
+        reverseMapping[triplet] = codon;
+      }
+    }
+    mapping = reverseMapping;
   }
+  return mapping;
 }
 
 function codonsToDNA() {
-  var dict = getDict();
-  var input = document.getElementById("codons").value.replace(/[\s\d]/g,"");
-  input = input.toUpperCase();
-  var out = "";
-  var as = 0;
-  var cs = 0;
-  var ts = 0;
-  var gs = 0;
-  for (var i=0; i < input.length; i++) {
-    if (!(input[i] in dict)) {
-      alert("The character \"" + input[i] + "\" at position " + i + " is invalid.");
+  let mapping = codonMapping(false);
+  let codons = document.getElementById("codons").value;
+  let dna = "";
+  let stats = { 'a': 0, 'c': 0, 't': 0, 'g': 0 };
+
+  let rng = new Math.seedrandom(document.getElementById("seed").value);
+
+  for (let character of codons) {
+    if (/[\s\d]/.test(character)) {
+      dna += character;
+      continue;
+    }
+
+    let codon = character.toUpperCase();
+    if (!(codon in mapping)) {
+      alert("The character \"" + codon + "\" at position " + i + " is invalid.");
       return;
     }
-    var choices = dict[input[i]];
-    var chnum = Math.floor(Math.random() * choices.length);
+    let options = mapping[codon];
+    let choice = options[Math.floor(rng() * options.length)];
 
-    out += choices[chnum];
-    for (var j=0; j < choices[chnum].length; j++) {
-      if (choices[chnum][j] == 'a') { as++; }
-      if (choices[chnum][j] == 'c') { cs++; }
-      if (choices[chnum][j] == 't') { ts++; }
-      if (choices[chnum][j] == 'g') { gs++; }
+    dna += choice;
+    for (let j = 0; j < choice.length; j++) {
+      stats[choice[j]] = (stats[choice[j]] || 0) + 1;
     }
   }
-  document.getElementById("DNA").value = out;
+  document.getElementById("DNA").value = dna;
 
-  var analytics = "<table><tr><td>Letter</td>"
-    + "<td>Occourences</td></tr><tr><td>a</td><td>" + as + "</td></tr>"
-    + "<tr><td>c</td><td>" + cs + "</td></tr><tr><td>t</td><td>"
-    + ts + "</td></tr><tr><td>g</td><td>" + gs + "</td></tr></table>"
-    + "<p>GC ratio: " + ((gs + cs)/(as+ts+gs+cs) * 100) + "%</p>";
-  document.getElementById("analytics").innerHTML = analytics; 
+  let gcRatio = (stats.g + stats.c) / (stats.a + stats.t + stats.g + stats.c);
+  let analytics = "<table>"
+    + "<tr><td>Letter</td><td>Occurrences</td></tr>"
+    + "<tr><td>a</td><td>" + stats.a + "</td></tr>"
+    + "<tr><td>c</td><td>" + stats.c + "</td></tr>"
+    + "<tr><td>t</td><td>" + stats.t + "</td></tr>"
+    + "<tr><td>g</td><td>" + stats.g + "</td></tr>"
+    + "</table>"
+    + "<p>GC ratio: " + (gcRatio * 100).toFixed(2) + "%</p>";
+  document.getElementById("analytics").innerHTML = analytics;
 }
 
 function DNAToCodons() {
-  var dict = getDict();
-  var input = document.getElementById("DNA").value.replace(/[\s\d]/g,"");
-  input = input.toLowerCase();
-  var out = "";
-  for (var i=0; i < input.length; i++) {
-    if (input[i] < "0" || input[i] > "9") {
-      if (!"actg".includes(input[i])) {
-        alert("The character \"" + input[i] + "\" at position " + i + " is invalid.");
-        return;
-      }
-    }
-  }
-  for (var i=0; i < input.length; i+=3) {
-    if (input[i] < "0" || input[i] > "9") {
-      var t = "" + input[i] + input[i+1] + input[i+2];
-      var c = undefined;
-      for (codon in dict) {
-        for (triplet in dict[codon]) {
-          if (t == dict[codon][triplet]) {
-            c = codon;
-          }
-        }
-      }
-      if (c == undefined) {
-        //we have not found any codon for the DNA triplet
-        alert("The DNA triplet \"" + t + "\" at position " + i + " is invalid. Maybe try Selecting \"Pichia\" from the dropdown at the top since it supports all codons.");
-        return;
-      }
+  let mapping = codonMapping(true);
+  let dna = document.getElementById("DNA").value.replace(/[\s\d]/g, "").toLowerCase();
+  let codons = "";
+  let stats = {};
 
-      out += c;
+  for (let i = 0; i < dna.length;) {
+    let triplet = "" + dna[i] + dna[i + 1] + dna[i + 2];
+    if (!(triplet in mapping)) {
+      //we have not found any codon for the DNA triplet
+      alert("The DNA triplet \"" + triplet + "\" at position " + i + " is invalid. Maybe try Selecting the \"Pichia\" preset at the top since it supports all codons.");
+      return;
     }
+
+    let codon = mapping[triplet];
+    stats[codon] = (stats[codon] || 0) + 1;
+    codons += codon;
+    i += 3;
   }
-  document.getElementById("codons").value = out;
-  document.getElementById("analytics").innerHTML = "";
+
+  document.getElementById("codons").value = codons;
+
+
+  let sorted = [];
+  for (let codon in stats) {
+    sorted.push([codon, stats[codon]]);
+  }
+  sorted.sort((a, b) => b[1] - a[1]); // sort descending by occurrences
+  let analytics = "<table><tr><td>Letter</td><td>Occurrences</td></tr>";
+  for (let stat of sorted) {
+    analytics += "<tr><td>" + stat[0] + "</td><td>" + stat[1] + "</td></tr>";
+  }
+  analytics += "</table>";
+  document.getElementById("analytics").innerHTML = analytics;
 }
 
 function checkForRepeats() {
-  var analytics = "<table><tr><td>Sequence</td><td>Occourences</td></tr>";
-  var dna = document.getElementById("DNA").value.replace(/[\s\d]/g,"");
-  var minrep = parseInt(document.getElementById("minrep").value);
-  var maxrep = parseInt(document.getElementById("maxrep").value);
+  let dna = document.getElementById("DNA").value.replace(/[\s\d]/g, "");
+  let minrep = parseInt(document.getElementById("minrep").value);
+  let maxrep = parseInt(document.getElementById("maxrep").value);
 
-  var repDict = {}; //count the repetitions of all occourances 10+bp long
-  for (var r = maxrep; r >= minrep; r--) {
+  let repetitions = {}; //count the repetitions of all occurrences 10+bp long
+  for (let r = maxrep; r >= minrep; r--) {
     //dna.length/2 is picked as things have to repeat at least twice.
-    for (var i = 0; i + r <= dna.length; i++) {
+    for (let i = 0; i + r <= dna.length; i++) {
       let selection = dna.slice(i, i + r);
       //increment the count of the selection
-      if (repDict[selection] == undefined) {
-        repDict[selection] = 1;
-      } else {
-        repDict[selection] += 1;
-      }
+      repetitions[selection] = (repetitions[selection] || 0) + 1;
     }
-    for (sequence in repDict) {
+    for (let sequence in repetitions) {
       //delete all sequences that do not repeat
-      if (repDict[sequence] == 1) {
-        delete repDict[sequence];
+      if (repetitions[sequence] == 1) {
+        delete repetitions[sequence];
       }
     }
   }
-  for (sequence in repDict) {
-    if (repDict[sequence] > 1) {
-      //list in analytics table
-      analytics += "<tr><td>" + sequence + "</td><td>" + repDict[sequence]
-        + "</td></tr>";
-    }
+  let sorted = [];
+  for (let sequence in repetitions) {
+    sorted.push([sequence, repetitions[sequence]]);
+  }
+  sorted.sort((a, b) => (b[1] - a[1]) * 1000 + b[0].length - a[0].length); // sort descending by occurrences, then length
+
+  let analytics = "<table><tr><td>Sequence</td><td>Length</td><td>Occurrences</td></tr>";
+  for (let repetition of sorted) {
+    analytics += "<tr><td class=\"mono\">" + repetition[0] + "</td><td>" + repetition[0].length + "</td><td>" + repetition[1] + "</td></tr>";
   }
   analytics += "</table>";
-    
-  document.getElementById("repeats").innerHTML = analytics; 
+
+  document.getElementById("repeats").innerHTML = analytics;
 }
+
+window.presets = {
+'human':
+`A: gct,gcc,gca
+R: cgg,aga,agg
+N: aat,aac
+D: gat,gac
+C: tgt,tgc
+Q: caa,cag
+E: gaa,gag
+G: ggt,ggc,gga,ggg
+H: cat,cac
+I: att,atc
+L: ctt,ctc,ctg,ttg
+K: aaa,aag
+M: atg
+F: ttt,ttc
+P: cct,ccc,cca
+S: tct,tcc,tca,agt,agc
+T: act,acc,aca
+W: tgg
+Y: tat,tac
+V: gtt,gtc,gtg
+*: taa,tga,tag`,
+'drosophila':
+`A: gct,gcc,gca,gcg
+R: cgt,cgc
+N: aat,aac
+D: gat,gac
+C: tgt,tgc
+Q: caa,cag
+E: gaa,gag
+G: ggt,ggc,gga
+H: cat,cac
+I: att,atc
+L: ctc,ctg,ttg
+K: aaa,aag
+M: atg
+F: ttt,ttc
+P: ccc,cca,ccg
+S: tcc,tcg,agt,agc
+T: act,acc,aca,acg
+W: tgg
+Y: tat,tac
+V: gtt,gtc,gtg
+*: taa,tga,tag`,
+'mouse':
+`A: gct,gcc,gca
+R: cgc,cgg,aga,agg
+N: aat,aac
+D: gat,gac
+C: tgt,tgc
+Q: caa,cag
+E: gaa,gag
+G: ggt,ggc,gga,ggg
+H: cat,cac
+I: att,atc
+L: ctt,ctc,ctg,ttg
+K: aaa,aag
+M: atg
+F: ttt,ttc
+P: cct,ccc,cca
+S: tct,tcc,tca,agt,agc
+T: act,acc,aca
+W: tgg
+Y: tat,tac
+V: gtt,gtc,gtg
+*: taa,tga,tag`,
+'saccharomyces':
+`A: gct,gcc,gca
+R: aga,agg
+N: aat,aac
+D: gat,gac
+C: tgt,tgc
+Q: caa,cag
+E: gaa,gag
+G: ggt,ggc,gga
+H: cat,cac
+I: att,atc,ata
+L: ctt,cta,ctg,tta,ttg
+K: aaa,aag
+M: atg
+F: ttt,ttc
+P: cct,cca
+S: tct,tcc,tca,agt,agc
+T: act,acc,aca
+W: tgg
+Y: tat,tac
+V: gtt,gtc,gta,gtg
+*: taa,tga,tag`,
+'arabidopsis':
+`A: gct,gcc,gca
+R: aga,agg
+N: aat,aac
+D: gat,gac
+C: tgt,tgc
+Q: caa,cag
+E: gaa,gag
+G: ggt,ggc,gga,ggg
+H: cat,cac
+I: att,atc,ata
+L: ctt,ctc,cta,ctg,tta,ttg
+K: aaa,aag
+M: atg
+F: ttt,ttc
+P: cct,cca
+S: tct,tcc,tca,tcg,agt,agc
+T: act,acc,aca
+W: tgg
+Y: tat,tac
+V: gtt,gtc,gta,gtg
+*: taa,tga,tag`,
+'all':
+`A: gct,gcc,gca,gcg
+R: cgt,cgc,cga,cgg,aga,agg
+N: aat,aac
+D: gat,gac
+C: tgt,tgc
+Q: caa,cag
+E: gaa,gag
+G: ggt,ggc,gga,ggg
+H: cat,cac
+I: att,atc,ata
+L: ctt,ctc,cta,ctg,tta,ttg
+K: aaa,aag
+M: atg
+F: ttt,ttc
+P: cct,ccc,cca,ccg
+S: tct,tcc,tca,tcg,agt,agc
+T: act,acc,aca,acg
+W: tgg
+Y: tat,tac
+V: gtt,gtc,gta,gtg
+*: taa,tga,tag`
+};
+
+function loadPreset(presetName) {
+  document.getElementById("codondict").innerHTML = presets[presetName];
+}
+
+document.addEventListener('DOMContentLoaded', (e) => {
+  document.getElementById("seed").value = Math.floor(Math.random() * 100000000);
+});

--- a/scripts/codonscromble/codonscromble.js
+++ b/scripts/codonscromble/codonscromble.js
@@ -29,19 +29,15 @@ function codonMapping(reverse) {
 
 function codonsToDNA() {
   let mapping = codonMapping(false);
-  let codons = document.getElementById("codons").value;
+  let codons = document.getElementById("codons").value.replace(/[\s\d]/g, "").toUpperCase();
   let dna = "";
   let stats = { 'a': 0, 'c': 0, 't': 0, 'g': 0 };
 
-  let rng = new Math.seedrandom(document.getElementById("seed").value);
+  let seed = document.getElementById("seed").value;
+  let rng = seed == "" ? new Math.seedrandom() : new Math.seedrandom(seed);
 
-  for (let character of codons) {
-    if (/[\s\d]/.test(character)) {
-      dna += character;
-      continue;
-    }
-
-    let codon = character.toUpperCase();
+  for (let i in codons) {
+    let codon = codons[i];
     if (!(codon in mapping)) {
       alert("The character \"" + codon + "\" at position " + i + " is invalid.");
       return;
@@ -277,7 +273,3 @@ V: gtt,gtc,gta,gtg
 function loadPreset(presetName) {
   document.getElementById("codondict").innerHTML = presets[presetName];
 }
-
-document.addEventListener('DOMContentLoaded', (e) => {
-  document.getElementById("seed").value = Math.floor(Math.random() * 100000000);
-});


### PR DESCRIPTION
- Switched to an easier to use a custom format for the codon dictionary
- Made codon key clearer
- Added a seeded RNG
- Preserve whitespace and digits in DNA output
- Truncate GC ratio to two decimal digits
- Sort repetitions by descending count
- Make preset buttons that load directly into the codon dictionary

Is the repetition length or repetition count is more important? At the moment I'm sorting by repetition count and then repetition length, but I don't understand genetic engineering, so it may be more useful to sort by length and then count.